### PR TITLE
Remove symbols with negative prices from calculations

### DIFF
--- a/data_load.R
+++ b/data_load.R
@@ -16,7 +16,13 @@ query_data <- function(index, from, to){
 
 
 process_data <- function(data){
+  bad_symbols <- data %>% 
+    filter(price <= 0) %>% 
+    .$symbol %>% 
+    unique()
+  
   data %>% 
+    filter(!(symbol %in% bad_symbols)) %>% 
     select(date, price, symbol) %>%  
     spread(key=symbol, value=price) %>% 
     fill() %>% 


### PR DESCRIPTION
Some data coming from Yahoo finance had errors - prices were negative. 
Fixed by filtering step during data loading.
closes #18 